### PR TITLE
Allowing to get annotation-based IC by using key (term)/ value (stati…

### DIFF
--- a/pysml-dev/PySML/informationcontent.py
+++ b/pysml-dev/PySML/informationcontent.py
@@ -293,22 +293,42 @@ class InformationContent(object):
 		if not TermStats or not isinstance(TermStats, dict): # Break it as TermStats is empty or not a dictionary
 			print(InputError('TermStats Value or Type Error', 'TermStats type and value on line 299, if provided, should be a dictionary\nkey (term)/value (statistical count) mapping\n\nPlease refer to the tool documentation, fix this issue and try again ...\n'))
 			sys.exit(3)
-
-		tinfo = {}
-		for t in self.DagStr:
-			tinfo[t] = TermStats[self.Dag[t]] if self.Dag[t] in TermStats else 0
+		ctinfo = {}
 		rlevel = sorted(list(set(self.DicLevels.values())))
-		if not tinfo:
-			print(InputError('Ontology terms error or not found', 'TermStats dictionary: key (term)/value (statistical count) mapping\nNo term provided in TermStats is in the current version of the ontology.\n\nPlease refer to the tool documentation, fix this issue and try again ...\n'))
-			sys.exit(4)
 		
-		for i in rlevel:
-			for j in [c for c in self.DicLevels if self.DicLevels[c]==i]:
-				tinfo[j] += sum([tinfo[k] for k in self.DagStr[j]])
-		troot = tinfo[self.oroot]; ctinfo = {}
-		for t in tinfo:
-			 try: ctinfo[t]= -LOG(1.0*tinfo[t]/troot)
-			 except: pass
+		if(isinstance(list(TermStats.values())[0],int)):
+			
+			tinfo = {}
+			for t in self.DagStr:
+				tinfo[t] = TermStats[self.Dag[t]] if self.Dag[t] in TermStats else 0
+			
+			if not tinfo:
+				print(InputError('Ontology terms error or not found', 'TermStats dictionary: key (term)/value (statistical count or entity list) mapping\nNo term provided in TermStats is in the current version of the ontology.\n\nPlease refer to the tool documentation, fix this issue and try again ...\n'))
+				sys.exit(4)
+			troot = tinfo[self.oroot]
+			
+			for t in tinfo:
+				try: ctinfo[t]= -LOG(1.0*tinfo[t]/troot)
+				except: pass
+		else:
+			
+			tinfo = {}
+			for t in self.DagStr:
+				tinfo[t] = set(TermStats[self.Dag[t]]) if self.Dag[t] in TermStats else set()
+			
+			for i in rlevel:
+				for j in [c for c in self.DicLevels if self.DicLevels[c]==i]:
+					for k in self.DagStr[j]:
+						tinfo[j] = tinfo[j].union(tinfo[k])
+			if not tinfo:
+					print(InputError('Ontology terms error or not found', 'TermStats dictionary: key (term)/value (statistical count or entity list) mapping\nNo term provided in TermStats is in the current version of the ontology.\n\nPlease refer to the tool documentation, fix this issue and try again ...\n'))
+					sys.exit(4)
+			troot = 1.0*len(tinfo[self.oroot])
+			print(troot)
+			for t in tinfo:
+				 try: ctinfo[t]= -LOG(1.0*len(tinfo[t])/troot)
+				 except: pass
+		
 		return ctinfo
 
 	def virtualIC(self, **kwargs):

--- a/pysml-dev/setup.py
+++ b/pysml-dev/setup.py
@@ -1,22 +1,16 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
-from platform import python_version_tuple
+from setuptools import setup
 import re
 
 LICENSE = open("LICENSE").read()
 
-VERSION = open("VERSION").read()
-
+VERSION = '2.5.1'
 # strip links from the descripton on the PyPI
 LONG_DESCRIPTION = open("README.rst").read().replace("`_", "`")
 
-# strip Build Status from the PyPI package
-if python_version_tuple()[:2] >= ('2', '7'):
-    LONG_DESCRIPTION = re.sub("^Build status\n(.*\n){7}", "", LONG_DESCRIPTION, flags=re.M)
 
 setup(name='PySML Interface',
-   version=VERSION,
    description='\n'+68*'*'+'\n* An open Python library implementing Semantic Similarity Measures *'+'\n* and common related applications'.ljust(68)+'*\n'+68*'*'+'\n',
    long_description=LONG_DESCRIPTION,
    author='Gaston K. Mazandu et al.',
@@ -25,6 +19,7 @@ setup(name='PySML Interface',
    maintainer_email = 'gaston.mazandu@uct.ac.za, gmazandu@gmail.com, kuzamunu@aims.ac.za',
    url='http://web.cbio.uct.ac.za/ITGOM/post-analysis-tools/mysml-dev/\nhttps://github.com/gkm-software-dev/post-analysis-tools',
    license=LICENSE,
+   version=VERSION,
    classifiers= [ "Development Status :: 4 - Beta",
                   "License :: OSI Approved :: GNU General Public License",
                   "Operating System :: OS Independent, but tested only on Linux",


### PR DESCRIPTION
Hi,

I found a mistake in the annotation-based IC function. The numerical values are transferred from children to parent.
That provides an error for the real annotation-based IC. For example, the term A is annotating the
entities 1, 2, and 3. Then, the parent B is annotating the entities 3 and 4. By using counts, A and B have 3 and
2 entities, and using your code, B will have (thanks to the true path rule) a total of 5. That is an error since
A intersect B is equal to 3 (therefore the term B should have a count of 4). My modifications include the following:

    - remove the transfer of counts between children and parents. Then the user need to include a key/value
      where count(parent)>count(children)
    - add a new step to allow users to include a dict() with key representing the keys and the value represent a list of
      entities. For example, with that code we can run the following code:

      from PySLM import *
      ICScores = InformationContent()
      TermStats = {'GO:0140253': ['Prot1', 'Prot2'], 'GO:0009987': ['Prot3'], 'GO:0008150': ['Prot4']}
      ICScores.getIC(['stats'], ['GO:0140253','GO:0009987','GO:0008150'],TermStats=TermStats)

The code works very well, the modification can be observed during the merge step in git.